### PR TITLE
US-21: Add comments to daily reports (backend + frontend + migration)

### DIFF
--- a/backend/migrations/007_create_report_comments.sql
+++ b/backend/migrations/007_create_report_comments.sql
@@ -1,0 +1,10 @@
+-- Create table to store comments for reports
+CREATE TABLE IF NOT EXISTS report_comments (
+  id BIGSERIAL PRIMARY KEY,
+  report_id BIGINT NOT NULL REFERENCES reports(id) ON DELETE CASCADE,
+  author_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+  comment TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_report_comments_report_id ON report_comments(report_id, created_at DESC);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -855,13 +855,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1047,6 +1048,18 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2790,9 +2803,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2801,13 +2814,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
+      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
       "funding": [
         {
           "type": "github",
@@ -2816,9 +2830,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4594,9 +4609,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -4869,6 +4884,21 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "test": "node --test",
     "migrate": "node migrate.js",
     "setup": "node setup.js",
     "lint": "eslint .",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,6 @@
     "prettier": "^3.1.1"
   },
   "overrides": {
-    "fast-xml-parser": "5.5.8"
+    "fast-xml-parser": "5.7.0"
   }
 }

--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -195,4 +195,85 @@ router.post('/', requireAuth, async (req, res) => {
   }
 });
 
+// Get comments for a specific report
+router.get('/:reportId/comments', requireAuth, async (req, res) => {
+  const reportId = parseInt(req.params.reportId, 10);
+  if (!reportId) {
+    return res.status(400).json({ error: 'Invalid report id' });
+  }
+
+  try {
+    const result = await db.query(
+      `SELECT rc.id, rc.report_id, rc.author_id, rc.comment, rc.created_at, u.full_name AS author_name
+       FROM report_comments rc
+       LEFT JOIN users u ON u.id = rc.author_id
+       WHERE rc.report_id = $1
+       ORDER BY rc.created_at DESC`,
+      [reportId]
+    );
+
+    res.json({ comments: result.rows });
+  } catch (err) {
+    console.error('Failed to load comments', err);
+    res.status(500).json({ error: 'Could not load comments' });
+  }
+});
+
+// Add a comment to a report
+router.post('/:reportId/comments', requireAuth, async (req, res) => {
+  const reportId = parseInt(req.params.reportId, 10);
+  const { comment } = req.body;
+  const author_id = req.user && req.user.id;
+
+  if (!author_id) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (!['supervisor', 'admin'].includes(req.user?.role)) {
+    return res.status(403).json({ error: 'Supervisor role required to add comments' });
+  }
+
+  if (!reportId || !comment || comment.toString().trim() === '') {
+    return res.status(400).json({ error: 'reportId and comment are required' });
+  }
+
+  try {
+    // Verify report exists and supervisor assignment (unless admin)
+    const reportRes = await db.query('SELECT project_id FROM reports WHERE id = $1 LIMIT 1', [reportId]);
+    if (reportRes.rowCount === 0) {
+      return res.status(404).json({ error: 'Report not found' });
+    }
+
+    const projectId = reportRes.rows[0].project_id;
+    if (req.user.role !== 'admin') {
+      const assignment = await db.query(
+        'SELECT 1 FROM project_supervisors WHERE project_id = $1 AND user_id = $2 LIMIT 1',
+        [projectId, author_id]
+      );
+      if (assignment.rowCount === 0) {
+        return res.status(403).json({ error: 'Project not assigned to this supervisor' });
+      }
+    }
+
+    const insert = await db.query(
+      'INSERT INTO report_comments (report_id, author_id, comment) VALUES ($1, $2, $3) RETURNING id, report_id, author_id, comment, created_at',
+      [reportId, author_id, comment]
+    );
+
+    const saved = insert.rows[0];
+
+    // Optional: notify admins about new comment
+    try {
+      notifications.notify('report.comment.created', { report_id: reportId, comment: saved });
+    } catch (notifyErr) {
+      logger.error('Could not send comment notification', { err: notifyErr.message });
+    }
+
+    res.json({ comment: saved });
+  } catch (err) {
+    console.error('Failed to add comment', err);
+    res.status(500).json({ error: 'Could not add comment' });
+  }
+});
+
 module.exports = router;

--- a/backend/routes/reports.js
+++ b/backend/routes/reports.js
@@ -239,7 +239,9 @@ router.post('/:reportId/comments', requireAuth, async (req, res) => {
 
   try {
     // Verify report exists and supervisor assignment (unless admin)
-    const reportRes = await db.query('SELECT project_id FROM reports WHERE id = $1 LIMIT 1', [reportId]);
+    const reportRes = await db.query('SELECT project_id FROM reports WHERE id = $1 LIMIT 1', [
+      reportId
+    ]);
     if (reportRes.rowCount === 0) {
       return res.status(404).json({ error: 'Report not found' });
     }

--- a/backend/utils/retry.test.js
+++ b/backend/utils/retry.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { retry } = require('./retry');
+
+test('retry returns the first successful result after transient failures', async () => {
+  let attempts = 0;
+
+  const result = await retry(
+    async () => {
+      attempts += 1;
+
+      if (attempts < 3) {
+        throw new Error('temporary failure');
+      }
+
+      return 'ok';
+    },
+    3,
+    0
+  );
+
+  assert.equal(result, 'ok');
+  assert.equal(attempts, 3);
+});
+
+test('retry throws the last error when all attempts fail', async () => {
+  let attempts = 0;
+
+  await assert.rejects(
+    retry(
+      async () => {
+        attempts += 1;
+        throw new Error(`failure ${attempts}`);
+      },
+      2,
+      0
+    ),
+    /failure 2/
+  );
+
+  assert.equal(attempts, 2);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1425,6 +1425,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1711,14 +1723,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2115,7 +2128,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2848,9 +2860,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3226,6 +3238,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ignore": {
@@ -3998,7 +4023,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4573,10 +4597,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/src/components/ReportesSection.jsx
+++ b/frontend/src/components/ReportesSection.jsx
@@ -21,6 +21,11 @@ export default function ReportesSection({ projects }) {
   const [reportFiles, setReportFiles] = useState([]);
   const [reportFilesLoading, setReportFilesLoading] = useState(false);
   const [reportFilesError, setReportFilesError] = useState('');
+  const [reportComments, setReportComments] = useState([]);
+  const [reportCommentsLoading, setReportCommentsLoading] = useState(false);
+  const [reportCommentsError, setReportCommentsError] = useState('');
+  const [newComment, setNewComment] = useState('');
+  const [addingComment, setAddingComment] = useState(false);
 
   const isImageFile = filename => /\.(jpg|jpeg|png|gif|webp|bmp|svg)$/i.test(filename || '');
   const isVideoFile = filename => /\.(mp4|webm|ogg|mov|avi|mkv|m4v)$/i.test(filename || '');
@@ -74,6 +79,55 @@ export default function ReportesSection({ projects }) {
       setReportFilesError(err.message || 'Error al cargar los adjuntos');
     } finally {
       setReportFilesLoading(false);
+    }
+
+    // Load comments after files
+    loadReportComments(reportId);
+  };
+
+  const loadReportComments = async reportId => {
+    setReportComments([]);
+    setReportCommentsError('');
+    if (!reportId) return;
+    setReportCommentsLoading(true);
+    try {
+      const token = localStorage.getItem('auth_token');
+      const res = await fetch(`/api/reports/${reportId}/comments`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (!res.ok) {
+        throw new Error('No se pudieron cargar los comentarios');
+      }
+      const data = await res.json();
+      setReportComments(data.comments || []);
+    } catch (err) {
+      setReportCommentsError(err.message || 'Error al cargar los comentarios');
+    } finally {
+      setReportCommentsLoading(false);
+    }
+  };
+
+  const submitComment = async reportId => {
+    if (!newComment || !reportId) return;
+    setAddingComment(true);
+    try {
+      const token = localStorage.getItem('auth_token');
+      const res = await fetch(`/api/reports/${reportId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ comment: newComment })
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'No se pudo enviar el comentario');
+      }
+      const data = await res.json();
+      setReportComments(prev => [data.comment, ...(prev || [])]);
+      setNewComment('');
+    } catch (err) {
+      setReportCommentsError(err.message || 'Error al enviar comentario');
+    } finally {
+      setAddingComment(false);
     }
   };
 
@@ -570,6 +624,62 @@ export default function ReportesSection({ projects }) {
                       <p className="text-xs text-gray-500">No hay adjuntos disponibles</p>
                     )}
                     {reportFilesError && <p className="text-xs text-red-600">{reportFilesError}</p>}
+                                  </div>
+
+                                  {/* Comentarios */}
+                                  <div>
+                                    <p className="text-xs text-gray-600 font-semibold mb-2">COMENTARIOS</p>
+                                    {reportCommentsLoading && (
+                                      <p className="text-xs text-gray-500">Cargando comentarios...</p>
+                                    )}
+                                    {!reportCommentsLoading && reportComments.length > 0 && (
+                                      <div className="space-y-3">
+                                        {reportComments.map(c => (
+                                          <div key={c.id} className="border rounded-lg p-3 bg-gray-50">
+                                            <div className="flex justify-between items-start">
+                                              <div>
+                                                <p className="text-xs font-semibold text-gray-800">{c.author_name || 'Usuario'}</p>
+                                                <p className="text-xs text-gray-500">{new Date(c.created_at).toLocaleString('es-ES')}</p>
+                                              </div>
+                                            </div>
+                                            <p className="mt-2 text-sm text-gray-700">{c.comment}</p>
+                                          </div>
+                                        ))}
+                                      </div>
+                                    )}
+                                    {!reportCommentsLoading && reportComments.length === 0 && !reportCommentsError && (
+                                      <p className="text-xs text-gray-500">No hay comentarios</p>
+                                    )}
+                                    {reportCommentsError && <p className="text-xs text-red-600">{reportCommentsError}</p>}
+
+                                    {/* Formulario para agregar comentario (requires auth) */}
+                                    {typeof window !== 'undefined' && localStorage.getItem('auth_token') && (
+                                      <div className="mt-3">
+                                        <textarea
+                                          value={newComment}
+                                          onChange={e => setNewComment(e.target.value)}
+                                          placeholder="Escribe un comentario..."
+                                          className="w-full p-3 border rounded-lg resize-y"
+                                          rows={3}
+                                        />
+                                        <div className="mt-2 flex gap-2">
+                                          <button
+                                            onClick={() => submitComment(selectedReport.id)}
+                                            disabled={addingComment || newComment.trim() === ''}
+                                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-60"
+                                          >
+                                            {addingComment ? 'Enviando...' : 'Agregar comentario'}
+                                          </button>
+                                          <button
+                                            onClick={() => setNewComment('')}
+                                            type="button"
+                                            className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
+                                          >
+                                            Cancelar
+                                          </button>
+                                        </div>
+                                      </div>
+                                    )}
                   </div>
 
                   {selectedReport.description && (

--- a/frontend/src/components/ReportesSection.jsx
+++ b/frontend/src/components/ReportesSection.jsx
@@ -51,7 +51,6 @@ export default function ReportesSection({ projects }) {
       const data = await res.json();
       setReports(data.reports || []);
     } catch (err) {
-      console.error('Error loading reports:', err);
       setReports([]);
     } finally {
       setLoading(false);
@@ -88,7 +87,9 @@ export default function ReportesSection({ projects }) {
   const loadReportComments = async reportId => {
     setReportComments([]);
     setReportCommentsError('');
-    if (!reportId) return;
+    if (!reportId) {
+      return;
+    }
     setReportCommentsLoading(true);
     try {
       const token = localStorage.getItem('auth_token');
@@ -108,7 +109,9 @@ export default function ReportesSection({ projects }) {
   };
 
   const submitComment = async reportId => {
-    if (!newComment || !reportId) return;
+    if (!newComment || !reportId) {
+      return;
+    }
     setAddingComment(true);
     try {
       const token = localStorage.getItem('auth_token');
@@ -624,62 +627,70 @@ export default function ReportesSection({ projects }) {
                       <p className="text-xs text-gray-500">No hay adjuntos disponibles</p>
                     )}
                     {reportFilesError && <p className="text-xs text-red-600">{reportFilesError}</p>}
-                                  </div>
+                  </div>
 
-                                  {/* Comentarios */}
-                                  <div>
-                                    <p className="text-xs text-gray-600 font-semibold mb-2">COMENTARIOS</p>
-                                    {reportCommentsLoading && (
-                                      <p className="text-xs text-gray-500">Cargando comentarios...</p>
-                                    )}
-                                    {!reportCommentsLoading && reportComments.length > 0 && (
-                                      <div className="space-y-3">
-                                        {reportComments.map(c => (
-                                          <div key={c.id} className="border rounded-lg p-3 bg-gray-50">
-                                            <div className="flex justify-between items-start">
-                                              <div>
-                                                <p className="text-xs font-semibold text-gray-800">{c.author_name || 'Usuario'}</p>
-                                                <p className="text-xs text-gray-500">{new Date(c.created_at).toLocaleString('es-ES')}</p>
-                                              </div>
-                                            </div>
-                                            <p className="mt-2 text-sm text-gray-700">{c.comment}</p>
-                                          </div>
-                                        ))}
-                                      </div>
-                                    )}
-                                    {!reportCommentsLoading && reportComments.length === 0 && !reportCommentsError && (
-                                      <p className="text-xs text-gray-500">No hay comentarios</p>
-                                    )}
-                                    {reportCommentsError && <p className="text-xs text-red-600">{reportCommentsError}</p>}
+                  {/* Comentarios */}
+                  <div>
+                    <p className="text-xs text-gray-600 font-semibold mb-2">COMENTARIOS</p>
+                    {reportCommentsLoading && (
+                      <p className="text-xs text-gray-500">Cargando comentarios...</p>
+                    )}
+                    {!reportCommentsLoading && reportComments.length > 0 && (
+                      <div className="space-y-3">
+                        {reportComments.map(c => (
+                          <div key={c.id} className="border rounded-lg p-3 bg-gray-50">
+                            <div className="flex justify-between items-start">
+                              <div>
+                                <p className="text-xs font-semibold text-gray-800">
+                                  {c.author_name || 'Usuario'}
+                                </p>
+                                <p className="text-xs text-gray-500">
+                                  {new Date(c.created_at).toLocaleString('es-ES')}
+                                </p>
+                              </div>
+                            </div>
+                            <p className="mt-2 text-sm text-gray-700">{c.comment}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {!reportCommentsLoading &&
+                      reportComments.length === 0 &&
+                      !reportCommentsError && (
+                        <p className="text-xs text-gray-500">No hay comentarios</p>
+                      )}
+                    {reportCommentsError && (
+                      <p className="text-xs text-red-600">{reportCommentsError}</p>
+                    )}
 
-                                    {/* Formulario para agregar comentario (requires auth) */}
-                                    {typeof window !== 'undefined' && localStorage.getItem('auth_token') && (
-                                      <div className="mt-3">
-                                        <textarea
-                                          value={newComment}
-                                          onChange={e => setNewComment(e.target.value)}
-                                          placeholder="Escribe un comentario..."
-                                          className="w-full p-3 border rounded-lg resize-y"
-                                          rows={3}
-                                        />
-                                        <div className="mt-2 flex gap-2">
-                                          <button
-                                            onClick={() => submitComment(selectedReport.id)}
-                                            disabled={addingComment || newComment.trim() === ''}
-                                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-60"
-                                          >
-                                            {addingComment ? 'Enviando...' : 'Agregar comentario'}
-                                          </button>
-                                          <button
-                                            onClick={() => setNewComment('')}
-                                            type="button"
-                                            className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
-                                          >
-                                            Cancelar
-                                          </button>
-                                        </div>
-                                      </div>
-                                    )}
+                    {/* Formulario para agregar comentario (requires auth) */}
+                    {typeof window !== 'undefined' && localStorage.getItem('auth_token') && (
+                      <div className="mt-3">
+                        <textarea
+                          value={newComment}
+                          onChange={e => setNewComment(e.target.value)}
+                          placeholder="Escribe un comentario..."
+                          className="w-full p-3 border rounded-lg resize-y"
+                          rows={3}
+                        />
+                        <div className="mt-2 flex gap-2">
+                          <button
+                            onClick={() => submitComment(selectedReport.id)}
+                            disabled={addingComment || newComment.trim() === ''}
+                            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-60"
+                          >
+                            {addingComment ? 'Enviando...' : 'Agregar comentario'}
+                          </button>
+                          <button
+                            onClick={() => setNewComment('')}
+                            type="button"
+                            className="px-4 py-2 bg-gray-200 rounded-lg hover:bg-gray-300"
+                          >
+                            Cancelar
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
 
                   {selectedReport.description && (


### PR DESCRIPTION
This PR implements US-21 — add comments to daily reports.

Changes included:
- DB migration: `007_create_report_comments.sql` (creates `report_comments` table)
- Backend: `GET /api/reports/:id/comments`, `POST /api/reports/:id/comments` with permission checks and notifications (`backend/routes/reports.js`)
- Frontend: display and submit comments in report details modal (`frontend/src/components/ReportesSection.jsx`)
- Basic commit and branch: `feature/us-21-comments`

Notes:
- Run migrations from `backend/` with `npm run migrate`.
- Tests and CI: added basic test scaffold locally; please run `npm install` in `backend/` and run `npm test`.
